### PR TITLE
Overlay blocklist

### DIFF
--- a/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsConfig.java
+++ b/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsConfig.java
@@ -151,8 +151,8 @@ public interface ImprovedTileIndicatorsConfig extends Config
 
 	@ConfigItem(
 			keyName = "excludedNPCs",
-			name = "NPCs to not draw overlay on",
-			description = "List of NPCs to not draw overlays on.",
+			name = "NPC IDs to not draw overlay on",
+			description = "Comma-separated list of NPC IDs to exclude from overlay draw-above / draw-below behavior.",
 			section = npcIndicatorsSection,
 			position = 9
 	)

--- a/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsConfig.java
+++ b/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsConfig.java
@@ -148,4 +148,23 @@ public interface ImprovedTileIndicatorsConfig extends Config
 			description = ""
 	)
 	void setTopNPCs(String npcsToDrawAbove);
+
+	@ConfigItem(
+			keyName = "excludedNPCs",
+			name = "NPCs to not draw overlay on",
+			description = "List of NPCs to not draw overlays on.",
+			section = npcIndicatorsSection,
+			position = 9
+	)
+	default String getExcludedNPCs()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+			keyName = "excludedNPCs",
+			name = "",
+			description = ""
+	)
+	void setExcludedNPCs(String excludedNPCs);
 }

--- a/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsPlugin.java
+++ b/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsPlugin.java
@@ -74,6 +74,7 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<NPC> onTopNpcs = new HashSet<>();
 	private List<String> onTopNPCNames = new ArrayList<>();
+	private List<String> excludedNPCNames = new ArrayList<>();
 
 	private static final String DRAW_ABOVE = "Draw-Above";
 	private static final String DRAW_BELOW = "Draw-Below";
@@ -160,6 +161,7 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 		{
 			final String npcName = getNameForCachedNPC(event.getIdentifier());
 			if (npcName == null) return;
+			if (excludedMatchesNPCName(npcName)) return;
 			boolean matchesList = onTopNPCNames.stream()
 					.filter(highlight -> !highlight.equalsIgnoreCase(npcName))
 					.anyMatch(highlight -> WildcardMatcher.matches(highlight, npcName));
@@ -210,9 +212,22 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 		return Text.fromCSV(configNpcs);
 	}
 
+	List<String> getExcludedNPCs()
+	{
+		final String configNpcs = config.getExcludedNPCs();
+
+		if (configNpcs.isEmpty())
+		{
+			return Collections.emptyList();
+		}
+
+		return Text.fromCSV(configNpcs);
+	}
+
 	void rebuild()
 	{
 		onTopNPCNames = getTopNPCs();
+		excludedNPCNames = getExcludedNPCs();
 		onTopNpcs.clear();
 
 		if (client.getGameState() != GameState.LOGGED_IN &&
@@ -239,7 +254,25 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 
 	private boolean onTopMatchesNPCName(String npcName)
 	{
+		if (excludedMatchesNPCName(npcName))
+		{
+			return false;
+		}
+
 		for (String matching : onTopNPCNames)
+		{
+			if (WildcardMatcher.matches(matching, npcName))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean excludedMatchesNPCName(String npcName)
+	{
+		for (String matching : excludedNPCNames)
 		{
 			if (WildcardMatcher.matches(matching, npcName))
 			{

--- a/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsPlugin.java
+++ b/src/main/java/io/leikvolle/tileindicators/ImprovedTileIndicatorsPlugin.java
@@ -74,7 +74,7 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<NPC> onTopNpcs = new HashSet<>();
 	private List<String> onTopNPCNames = new ArrayList<>();
-	private List<String> excludedNPCNames = new ArrayList<>();
+	private List<Integer> excludedNPCIds = new ArrayList<>();
 
 	private static final String DRAW_ABOVE = "Draw-Above";
 	private static final String DRAW_BELOW = "Draw-Below";
@@ -131,7 +131,7 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 			return;
 		}
 
-		if (onTopMatchesNPCName(npcName))
+		if (onTopMatchesNPCName(npcName) && !excludedMatchesNPCId(npc.getId()))
 		{
 			onTopNpcs.add(npc);
 		}
@@ -159,9 +159,11 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 
 		if (menuAction == MenuAction.EXAMINE_NPC && client.isKeyPressed(KeyCode.KC_SHIFT) && config.overlaysBelowNPCs())
 		{
+			final NPC npc = client.getTopLevelWorldView().npcs().byIndex(event.getIdentifier());
+			if (npc == null) return;
 			final String npcName = getNameForCachedNPC(event.getIdentifier());
 			if (npcName == null) return;
-			if (excludedMatchesNPCName(npcName)) return;
+			if (excludedMatchesNPCId(npc.getId())) return;
 			boolean matchesList = onTopNPCNames.stream()
 					.filter(highlight -> !highlight.equalsIgnoreCase(npcName))
 					.anyMatch(highlight -> WildcardMatcher.matches(highlight, npcName));
@@ -212,7 +214,7 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 		return Text.fromCSV(configNpcs);
 	}
 
-	List<String> getExcludedNPCs()
+	List<Integer> getExcludedNPCs()
 	{
 		final String configNpcs = config.getExcludedNPCs();
 
@@ -221,13 +223,27 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 			return Collections.emptyList();
 		}
 
-		return Text.fromCSV(configNpcs);
+		final List<Integer> excludedIds = new ArrayList<>();
+
+		for (String configNpc : Text.fromCSV(configNpcs))
+		{
+			try
+			{
+				excludedIds.add(Integer.parseInt(configNpc.trim()));
+			}
+			catch (NumberFormatException e)
+			{
+				log.debug("Skipping invalid excluded NPC id '{}'.", configNpc);
+			}
+		}
+
+		return excludedIds;
 	}
 
 	void rebuild()
 	{
 		onTopNPCNames = getTopNPCs();
-		excludedNPCNames = getExcludedNPCs();
+		excludedNPCIds = getExcludedNPCs();
 		onTopNpcs.clear();
 
 		if (client.getGameState() != GameState.LOGGED_IN &&
@@ -245,7 +261,7 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 				continue;
 			}
 
-			if (onTopMatchesNPCName(npcName))
+			if (onTopMatchesNPCName(npcName) && !excludedMatchesNPCId(npc.getId()))
 			{
 				onTopNpcs.add(npc);
 			}
@@ -254,11 +270,6 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 
 	private boolean onTopMatchesNPCName(String npcName)
 	{
-		if (excludedMatchesNPCName(npcName))
-		{
-			return false;
-		}
-
 		for (String matching : onTopNPCNames)
 		{
 			if (WildcardMatcher.matches(matching, npcName))
@@ -270,11 +281,11 @@ public class ImprovedTileIndicatorsPlugin extends Plugin
 		return false;
 	}
 
-	private boolean excludedMatchesNPCName(String npcName)
+	private boolean excludedMatchesNPCId(int npcId)
 	{
-		for (String matching : excludedNPCNames)
+		for (int excludedNpcId : excludedNPCIds)
 		{
-			if (WildcardMatcher.matches(matching, npcName))
+			if (excludedNpcId == npcId)
 			{
 				return true;
 			}


### PR DESCRIPTION
Added support for excluding specific NPCs from overlays. Usefull in the cases of such as [earthen shield](https://oldschool.runescape.wiki/w/Earthen_shield). 
With hider from Better NPC Highlight and Without the changes:
<img width="332" height="295" alt="without" src="https://github.com/user-attachments/assets/b2f6364c-9b29-42fb-942f-a21102043245" />
With hider from Better NPC Highlight and With the changes:
<img width="393" height="211" alt="with" src="https://github.com/user-attachments/assets/066146ff-e524-4324-9ad4-01717e2f0da7" />
Changed UI:
<img width="298" height="660" alt="UI" src="https://github.com/user-attachments/assets/70095447-202f-4ada-a2f8-8dadde18bc50" />
